### PR TITLE
todos#create の実装

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -5,8 +5,7 @@ class TodosController < ApplicationController
   end
 
   def create
-    todo = Todo.new(todo_params)
-    todo.save!
+    todo = Todo.create!(todo_params)
     render json: todo, status: :created
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -3,4 +3,16 @@ class TodosController < ApplicationController
     todos = Todo.all.order(:created_at)
     render json: todos
   end
+
+  def create
+    todo = Todo.new(todo_params)
+    todo.save!
+    render json: todo, status: :created
+  end
+
+  private
+
+  def todo_params
+    params.permit(:title, :text)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :todos, only: [:index]
+  resources :todos, only: [:index, :create]
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -39,4 +39,29 @@ RSpec.describe 'Todos', type: :request do
       end
     end
   end
+
+  describe 'POST /todos' do
+    subject { post '/todos', params: params }
+
+    let(:params) { { title: 'Sample title', text: 'Sample text' } }
+
+    it 'returns HTTP Status 201' do
+      subject
+      expect(response.status).to eq 201
+    end
+
+    it 'returns input params' do
+      subject
+      result_todo = JSON.parse(response.body)
+
+      aggregate_failures do
+        expect(result_todo['title']).to eq 'Sample title'
+        expect(result_todo['text']).to eq 'Sample text'
+      end
+    end
+
+    it 'create 1 todo' do
+      expect { subject }.to change(Todo, :count).by(1)
+    end
+  end
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -55,8 +55,10 @@ RSpec.describe 'Todos', type: :request do
       result_todo = JSON.parse(response.body)
 
       aggregate_failures do
+        expect(result_todo['id']).to_not be_empty
         expect(result_todo['title']).to eq 'Sample title'
         expect(result_todo['text']).to eq 'Sample text'
+        expect(result_todo['created_at']).to_not be_empty
       end
     end
 


### PR DESCRIPTION
このPRにおける目的
----
Todo を新規作成するための API を実装する。

やったこと
----
- `POST /todos` のルーティング設定
- todos#create の実装
  - 新規作成したデータを JSON 形式、ステータスを 201 で返す
- Request Spec の作成

動作確認
----
- [ ] Rails
  - `$ bin/setup` を実行
  - `$ bundle exec rails s` で Rails サーバーを起動
  - [ ] 他ターミナルで下記コマンドを実行し、新規作成したレコードが返ってくることを確認

  ```sh
  $ curl -X POST "http://localhost:3000/todos" -H "Content-Type: application/json" -H "accept: application/json" -d '{"title":"Sample title", "text": "Sample text"}'
  {
    "id": "fd0982b7-4b1c-4d44-a343-833e04557e50",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-16T06:15:47Z"
  }
  ```
- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認

このPRにおけるスコープ外
----
- 入力内容が空白の場合のエラー処理は他PRで実装します。
- HTTP Status 201 が返ってきた際の [Locationヘッダー](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Location)については `Todo#show` を実装してから考慮します。