### PR TITLE
todos#show の実装

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -9,6 +9,11 @@ class TodosController < ApplicationController
     render json: todo, status: :created
   end
 
+  def show
+    todo = Todo.find(params['id'])
+    render json: todo
+  end
+
   private
 
   def todo_params

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -6,7 +6,7 @@ class TodosController < ApplicationController
 
   def create
     todo = Todo.create!(todo_params)
-    render json: todo, status: :created
+    render json: todo, status: :created, location: todo
   end
 
   def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :todos, only: [:index, :create]
+  resources :todos, only: [:index, :create, :show]
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -47,7 +47,10 @@ RSpec.describe 'Todos', type: :request do
 
     it 'returns HTTP Status 201' do
       subject
-      expect(response.status).to eq 201
+      aggregate_failures do
+        expect(response.status).to eq 201
+        expect(response.location).to eq "http://www.example.com/todos/#{Todo.last.id}"
+      end
     end
 
     it 'returns input params' do

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Todos', type: :request do
     end
   end
 
-  describe 'GET /todos/{todo_id}' do
+  describe 'GET /todos/:id' do
     subject { get "/todos/#{todo.id}" }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -66,4 +66,29 @@ RSpec.describe 'Todos', type: :request do
       expect { subject }.to change(Todo, :count).by(1)
     end
   end
+
+  describe 'GET /todos/{todo_id}' do
+    subject { get "/todos/#{todo.id}" }
+
+    let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
+
+    it 'returns HTTP Status 200' do
+      subject
+      expect(response.status).to eq 200
+    end
+
+    it 'return valid JSON' do
+      expect_todo = {
+        'id' => todo.id,
+        'title' => 'Sample title',
+        'text' => 'Sample text',
+        'created_at' => '2019-01-01T00:00:00Z',
+      }
+
+      subject
+      result_todo = JSON.parse(response.body)
+
+      expect(result_todo).to eq expect_todo
+    end
+  end
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Todos', type: :request do
-  before { travel_to '2019-01-01T00:00:00Z' }
-
   describe 'GET /todos' do
     subject { get '/todos' }
+
+    before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo_first) { create(:todo, title: 'Sample title 1', text: 'Sample text 1') }
     let!(:todo_second) { create(:todo, title: 'Sample title 2', text: 'Sample text 2') }
@@ -72,6 +72,8 @@ RSpec.describe 'Todos', type: :request do
 
   describe 'GET /todos/:id' do
     subject { get "/todos/#{todo.id}" }
+
+    before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
 


### PR DESCRIPTION
このPRにおける目的
----
指定の Todo データを取得するための API を実装する。

やったこと
----
- `GET /todos/:id` のルーティング設定
- todos#show の実装
- Request Spec の作成

### その他
- [#8のコメント](https://github.com/chionyan/simple-todo-api/pull/8#discussion_r210491667)で指摘のあった Todo#create のレスポンスに Location を追加

動作確認
----

- [ ] Rails
  - `$ bin/setup` を実行
  - `$ bundle exec rails s` で Rails サーバーを起動
  - `id` 確認のため、新規レコードを作成する
  ```sh
  $ curl -X POST "http://localhost:3000/todos" -d "title=Sample title" -d "text=Sample text" 
  {
    "id": "2c63a32b-a5ca-4bc8-aa5f-c765ad573f09",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-17T06:27:04Z"
  }
  ```

  - [ ] `http://localhost:3000/todos/:id` に対して下記コマンドを実行し、先ほど作成したレコードが返ってくることを確認
  ```sh
  $ curl -X GET "http://localhost:3000/todos/2c63a32b-a5ca-4bc8-aa5f-c765ad573f09"
  {
    "id": "2c63a32b-a5ca-4bc8-aa5f-c765ad573f09",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-17T06:27:04Z"
  }
  ```

- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認

このPRにおけるスコープ外
----
- 存在しない URL にアクセスした際のエラー処理は他PRで実装します。