### PR TITLE
todos#update の実装

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -14,6 +14,12 @@ class TodosController < ApplicationController
     render json: todo
   end
 
+  def update
+    todo = Todo.find(params['id'])
+    todo.update!(todo_params)
+    render json: todo, location: todo
+  end
+
   private
 
   def todo_params

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,4 +1,6 @@
 class TodosController < ApplicationController
+  before_action :set_todo, only: [:show, :update]
+
   def index
     todos = Todo.all.order(:created_at)
     render json: todos
@@ -10,17 +12,19 @@ class TodosController < ApplicationController
   end
 
   def show
-    todo = Todo.find(params['id'])
-    render json: todo
+    render json: @todo
   end
 
   def update
-    todo = Todo.find(params['id'])
-    todo.update!(todo_params)
-    render json: todo, location: todo
+    @todo.update!(todo_params)
+    render json: @todo, location: @todo
   end
 
   private
+
+  def set_todo
+    @todo = Todo.find(params['id'])
+  end
 
   def todo_params
     params.permit(:title, :text)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :todos, only: [:index, :create, :show]
+  resources :todos, only: [:index, :create, :show, :update]
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -96,4 +96,32 @@ RSpec.describe 'Todos', type: :request do
       expect(result_todo).to eq expect_todo
     end
   end
+
+  describe 'PATCH /todos/:id' do
+    subject { patch "/todos/#{todo.id}", params: params }
+
+    before { travel_to '2019-01-01T00:00:00Z' }
+
+    let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
+    let(:params) { { title: 'Change title', text: 'Change text' } }
+
+    it 'returns HTTP Status 200' do
+      subject
+      expect(response.status).to eq 200
+    end
+
+    it 'returns update JSON' do
+      expect_todo = {
+        'id' => todo.id,
+        'title' => 'Change title',
+        'text' => 'Change text',
+        'created_at' => '2019-01-01T00:00:00Z',
+      }
+
+      subject
+      result_todo = JSON.parse(response.body)
+
+      expect(result_todo).to eq expect_todo
+    end
+  end
 end


### PR DESCRIPTION
このPRにおける目的
----
指定の Todo データを更新するための API を実装する。

やったこと
----
- `PATCH /todos/:id` のルーティング設定
- todos#update の実装
- Request Spec の作成

動作確認
----

- [ ] Rails
  - `$ bin/setup` を実行
  - `$ bundle exec rails s` で Rails サーバーを起動
  - `id` 確認のため、新規レコードを作成する
  ```sh
  $ curl -X POST "http://localhost:3000/todos" -d "title=Sample title" -d "text=Sample text" 
  {
    "id": "47706e63-f3f6-41b4-930f-a41eb08b2e5c",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-17T07:52:50Z"
  }
  ```

  - [ ] `http://localhost:3000/todos/:id` に対して下記コマンドを実行し、先ほど作成したレコードの `title` `text` が更新されて返ってくることを確認
  ```sh
  $ curl -X PATCH "http://localhost:3000/todos/47706e63-f3f6-41b4-930f-a41eb08b2e5c" -d "title=Change title" -d "text=Change text"
  {
    "id": "47706e63-f3f6-41b4-930f-a41eb08b2e5c",
    "title": "Change title",
    "text": "Change text",
    "created_at": "2018-08-17T07:52:50Z"
  }
  ```
- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認

このPRにおけるスコープ外
----
- 入力内容が空白の場合のエラー処理は他PRで実装します。
- 存在しない URL にアクセスした際のエラー処理は他PRで実装します。