### PR TITLE
todos#destroy の実装

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,4 +1,10 @@
 class TodosController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound,
+              ActionController::RoutingError do
+    errors = [{ title: '見つかりませんでした。', status: 404 }]
+    render json: { errors: errors }, status: 404
+  end
+
   def index
     todos = Todo.all.order(:created_at)
     render json: todos

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,5 +1,5 @@
 class TodosController < ApplicationController
-  before_action :set_todo, only: [:show, :update]
+  before_action :set_todo, only: [:show, :update, :destroy]
 
   rescue_from ActiveRecord::RecordNotFound,
               ActionController::RoutingError do
@@ -27,9 +27,8 @@ class TodosController < ApplicationController
   end
 
   def destroy
-    todo = Todo.find(params['id'])
-    todo.destroy!
-    render json: todo
+    @todo.destroy!
+    render json: @todo
   end
 
   private

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -2,7 +2,7 @@ class TodosController < ApplicationController
   before_action :set_todo, only: [:show, :update, :destroy]
 
   rescue_from ActiveRecord::RecordNotFound do
-    errors = [{ title: I18n.t('errors.messages.not_found'), status: 404 }]
+    errors = [{ title: I18n.t('errors.messages.not_found', locale: 'ja'), status: 404 }]
     render json: { errors: errors }, status: 404
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -2,7 +2,7 @@ class TodosController < ApplicationController
   before_action :set_todo, only: [:show, :update, :destroy]
 
   rescue_from ActiveRecord::RecordNotFound do
-    errors = [{ title: '見つかりませんでした。', status: 404 }]
+    errors = [{ title: I18n.t('errors.messages.not_found'), status: 404 }]
     render json: { errors: errors }, status: 404
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -20,6 +20,12 @@ class TodosController < ApplicationController
     render json: todo, location: todo
   end
 
+  def destroy
+    todo = Todo.find(params['id'])
+    todo.destroy!
+    render json: todo
+  end
+
   private
 
   def todo_params

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,8 +1,7 @@
 class TodosController < ApplicationController
   before_action :set_todo, only: [:show, :update, :destroy]
 
-  rescue_from ActiveRecord::RecordNotFound,
-              ActionController::RoutingError do
+  rescue_from ActiveRecord::RecordNotFound do
     errors = [{ title: '見つかりませんでした。', status: 404 }]
     render json: { errors: errors }, status: 404
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,5 @@ module SimpleTodoApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-    config.i18n.default_locale = :ja
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module SimpleTodoApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  errors:
+    messages:
+      not_found: 見つかりませんでした。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :todos, only: [:index, :create, :show, :update]
+  resources :todos
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -182,6 +182,10 @@ RSpec.describe 'Todos', type: :request do
 
         expect(result_errors).to eq expect_errors
       end
+
+      it 'not delete todo' do
+        expect { subject }.to_not change(Todo, :count)
+      end
     end
   end
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -124,4 +124,39 @@ RSpec.describe 'Todos', type: :request do
       expect(result_todo).to eq expect_todo
     end
   end
+
+  describe 'DELETE /todos/:id' do
+    subject { delete path }
+
+    before { travel_to '2019-01-01T00:00:00Z' }
+
+    let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
+
+    context 'Search Result Matching Criteria' do
+      let(:path) { "/todos/#{todo.id}" }
+
+      it 'returns HTTP Status 200' do
+        subject
+        expect(response.status).to eq 200
+      end
+
+      it 'returns delete JSON' do
+        expect_todo = {
+          'id' => todo.id,
+          'title' => 'Sample title',
+          'text' => 'Sample text',
+          'created_at' => '2019-01-01T00:00:00Z',
+        }
+
+        subject
+        result_todo = JSON.parse(response.body)
+
+        expect(result_todo).to eq expect_todo
+      end
+
+      it 'delete 1 todo' do
+        expect { subject }.to change(Todo, :count).by(-1)
+      end
+    end
+  end
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -158,5 +158,30 @@ RSpec.describe 'Todos', type: :request do
         expect { subject }.to change(Todo, :count).by(-1)
       end
     end
+
+    context 'Not Found' do
+      let(:path) { '/todos/0' }
+
+      it 'returns HTTP Status 404' do
+        subject
+        expect(response.status).to eq 404
+      end
+
+      it 'returns error JSON' do
+        expect_errors = {
+          'errors' => [
+            {
+              'title' => '見つかりませんでした。',
+              'status' => 404,
+            },
+          ],
+        }
+
+        subject
+        result_errors = JSON.parse(response.body)
+
+        expect(result_errors).to eq expect_errors
+      end
+    end
   end
 end

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Todos', type: :request do
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
 
-    context 'Search Result Matching Criteria' do
+    context 'Exist Record' do
       let(:path) { "/todos/#{todo.id}" }
 
       it 'returns HTTP Status 200' do
@@ -159,7 +159,7 @@ RSpec.describe 'Todos', type: :request do
       end
     end
 
-    context 'Not Found' do
+    context 'Not Exist Record' do
       let(:path) { '/todos/0' }
 
       it 'returns HTTP Status 404' do


### PR DESCRIPTION
このPRにおける目的
----
指定の Todo データを削除するための API を実装する。

やったこと
----
- `DELETE /todos/:id` のルーティング設定
- todos#destroy の実装
  - 存在しない URL に API リクエストを送った場合の例外処理も実装（動作確認のため）
- Request Spec の作成

動作確認
----

- [ ] Rails
  - `$ bin/setup` を実行
  - `$ bundle exec rails s` で Rails サーバーを起動
  - `id` 確認のため、新規レコードを作成する
  ```sh
  $ curl -X POST "http://localhost:3000/todos" -d "title=Sample title" -d "text=Sample text" 
  {
    "id": "3fb6b9a8-5cd1-403d-a914-c2dddc81f680",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-20T06:09:26Z"
  }
  ```
  - 下記コマンドを実行し、該当レコードを削除
  ```sh
  $ curl -X DELETE "http://localhost:3000/todos/3fb6b9a8-5cd1-403d-a914-c2dddc81f680"
  {
    "id": "3fb6b9a8-5cd1-403d-a914-c2dddc81f680",
    "title": "Sample title",
    "text": "Sample text",
    "created_at": "2018-08-20T06:09:26Z"
  }
  ```
  - [ ] 再度下記コマンドを実行し、レコードが削除されていることを確認
  ```sh
  $ curl -X DELETE "http://localhost:3000/todos/3fb6b9a8-5cd1-403d-a914-c2dddc81f680"
  {
    "errors": [
      {
        "title": "見つかりませんでした。",
        "status": 404
      }
    ]
  }
  ```

- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認

このPRにおけるスコープ外
----
- `rescue_from ActiveRecord::RecordNotFound` 追加によって `todos#show` `todos#update` の例外も捕捉できるようになりましたが、それらのテストは別PRで行います。
- [デフォルトのロケールファイル](https://github.com/svenfuchs/rails-i18n/)の追加