### PR TITLE
Not found 時のテストの追加

### DIFF
--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'Todos', type: :request do
 
       subject
       result_todos = JSON.parse(response.body)
-
       aggregate_failures do
         expect(result_todos.count).to eq 2
         expect(result_todos[0]).to eq expect_todo_first
@@ -56,7 +55,6 @@ RSpec.describe 'Todos', type: :request do
     it 'returns input params' do
       subject
       result_todo = JSON.parse(response.body)
-
       aggregate_failures do
         expect(result_todo['id']).to_not be_empty
         expect(result_todo['title']).to eq 'Sample title'
@@ -71,57 +69,111 @@ RSpec.describe 'Todos', type: :request do
   end
 
   describe 'GET /todos/:id' do
-    subject { get "/todos/#{todo.id}" }
+    subject { get path }
 
     before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
 
-    it 'returns HTTP Status 200' do
-      subject
-      expect(response.status).to eq 200
+    context 'Exist Record' do
+      let(:path) { "/todos/#{todo.id}" }
+
+      it 'returns HTTP Status 200' do
+        subject
+        expect(response.status).to eq 200
+      end
+
+      it 'return valid JSON' do
+        expect_todo = {
+          'id' => todo.id,
+          'title' => 'Sample title',
+          'text' => 'Sample text',
+          'created_at' => '2019-01-01T00:00:00Z',
+        }
+
+        subject
+        result_todo = JSON.parse(response.body)
+        expect(result_todo).to eq expect_todo
+      end
     end
 
-    it 'return valid JSON' do
-      expect_todo = {
-        'id' => todo.id,
-        'title' => 'Sample title',
-        'text' => 'Sample text',
-        'created_at' => '2019-01-01T00:00:00Z',
-      }
+    context 'Not Exist Record' do
+      let(:path) { '/todos/0' }
 
-      subject
-      result_todo = JSON.parse(response.body)
+      it 'returns HTTP Status 404' do
+        subject
+        expect(response.status).to eq 404
+      end
 
-      expect(result_todo).to eq expect_todo
+      it 'returns error JSON' do
+        expect_errors = {
+          'errors' => [
+            {
+              'title' => '見つかりませんでした。',
+              'status' => 404,
+            },
+          ],
+        }
+
+        subject
+        result_errors = JSON.parse(response.body)
+        expect(result_errors).to eq expect_errors
+      end
     end
   end
 
   describe 'PATCH /todos/:id' do
-    subject { patch "/todos/#{todo.id}", params: params }
+    subject { patch path, params: params }
 
     before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
     let(:params) { { title: 'Change title', text: 'Change text' } }
 
-    it 'returns HTTP Status 200' do
-      subject
-      expect(response.status).to eq 200
+    context 'Exist Record' do
+      let(:path) { "/todos/#{todo.id}" }
+
+      it 'returns HTTP Status 200' do
+        subject
+        expect(response.status).to eq 200
+      end
+
+      it 'returns update JSON' do
+        expect_todo = {
+          'id' => todo.id,
+          'title' => 'Change title',
+          'text' => 'Change text',
+          'created_at' => '2019-01-01T00:00:00Z',
+        }
+
+        subject
+        result_todo = JSON.parse(response.body)
+        expect(result_todo).to eq expect_todo
+      end
     end
 
-    it 'returns update JSON' do
-      expect_todo = {
-        'id' => todo.id,
-        'title' => 'Change title',
-        'text' => 'Change text',
-        'created_at' => '2019-01-01T00:00:00Z',
-      }
+    context 'Not Exist Record' do
+      let(:path) { '/todos/0' }
 
-      subject
-      result_todo = JSON.parse(response.body)
+      it 'returns HTTP Status 404' do
+        subject
+        expect(response.status).to eq 404
+      end
 
-      expect(result_todo).to eq expect_todo
+      it 'returns error JSON' do
+        expect_errors = {
+          'errors' => [
+            {
+              'title' => '見つかりませんでした。',
+              'status' => 404,
+            },
+          ],
+        }
+
+        subject
+        result_errors = JSON.parse(response.body)
+        expect(result_errors).to eq expect_errors
+      end
     end
   end
 
@@ -150,7 +202,6 @@ RSpec.describe 'Todos', type: :request do
 
         subject
         result_todo = JSON.parse(response.body)
-
         expect(result_todo).to eq expect_todo
       end
 
@@ -179,7 +230,6 @@ RSpec.describe 'Todos', type: :request do
 
         subject
         result_errors = JSON.parse(response.body)
-
         expect(result_errors).to eq expect_errors
       end
 

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -69,14 +69,12 @@ RSpec.describe 'Todos', type: :request do
   end
 
   describe 'GET /todos/:id' do
-    subject { get path }
-
     before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
 
     context 'Exist Record' do
-      let(:path) { "/todos/#{todo.id}" }
+      subject { get "/todos/#{todo.id}" }
 
       it 'returns HTTP Status 200' do
         subject
@@ -98,7 +96,7 @@ RSpec.describe 'Todos', type: :request do
     end
 
     context 'Not Exist Record' do
-      let(:path) { '/todos/0' }
+      subject { get '/todos/0' }
 
       it 'returns HTTP Status 404' do
         subject
@@ -123,15 +121,13 @@ RSpec.describe 'Todos', type: :request do
   end
 
   describe 'PATCH /todos/:id' do
-    subject { patch path, params: params }
-
     before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
     let(:params) { { title: 'Change title', text: 'Change text' } }
 
     context 'Exist Record' do
-      let(:path) { "/todos/#{todo.id}" }
+      subject { patch "/todos/#{todo.id}", params: params }
 
       it 'returns HTTP Status 200' do
         subject
@@ -153,7 +149,7 @@ RSpec.describe 'Todos', type: :request do
     end
 
     context 'Not Exist Record' do
-      let(:path) { '/todos/0' }
+      subject { patch '/todos/0', params: params }
 
       it 'returns HTTP Status 404' do
         subject
@@ -178,14 +174,12 @@ RSpec.describe 'Todos', type: :request do
   end
 
   describe 'DELETE /todos/:id' do
-    subject { delete path }
-
     before { travel_to '2019-01-01T00:00:00Z' }
 
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
 
     context 'Exist Record' do
-      let(:path) { "/todos/#{todo.id}" }
+      subject { delete "/todos/#{todo.id}" }
 
       it 'returns HTTP Status 200' do
         subject
@@ -211,7 +205,7 @@ RSpec.describe 'Todos', type: :request do
     end
 
     context 'Not Exist Record' do
-      let(:path) { '/todos/0' }
+      subject { delete '/todos/0' }
 
       it 'returns HTTP Status 404' do
         subject


### PR DESCRIPTION
このPRにおける目的
----
- [#11](https://github.com/chionyan/simple-todo-api/pull/11)でスコープ外としていた、`todos#show` `todos#update` で捕捉できる `ActiveRecord::RecordNotFound` の例外処理のテストの追加する。

やったこと
----
- `'GET /todos/:id'` `PATCH /todos/:id` の describe にレコードが存在しなかった時のテストを追加

動作確認
----

- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認
