### PR TITLE
BadRequest 時の例外処理の実装

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,6 +1,11 @@
 class TodosController < ApplicationController
   before_action :set_todo, only: [:show, :update, :destroy]
 
+  rescue_from ActionController::BadRequest do
+    errors = [{ title: I18n.t('errors.messages.bad_request', locale: 'ja'), status: 400 }]
+    render json: { errors: errors }, status: 400
+  end
+
   rescue_from ActiveRecord::RecordNotFound do
     errors = [{ title: I18n.t('errors.messages.not_found', locale: 'ja'), status: 404 }]
     render json: { errors: errors }, status: 404

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
   errors:
     messages:
+      bad_request: 不正なリクエストです。
       not_found: 見つかりませんでした。


### PR DESCRIPTION
このPRにおける目的
----
- [API 仕様](https://app.swaggerhub.com/apis/sukechannnn/TODO-API/1.0.0#/)に従い`GET /todos` における Bad request 時の例外処理を実装する

やったこと
----
- `ActionController::BadRequest` の例外処理実装

動作確認
----

- [ ] RSpec
  - `$ bundle exec rspec` を実行
  - [ ] `0 failures` が出力されることを確認
- [ ] Rubocop
  - `$ bundle exec rubocop` を実行
  - [ ] `no offenses detected` が出力されることを確認

このPRにおけるスコープ外
----