### PR TITLE
RecordInvalid 時の例外処理の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'rack-cors'
+gem 'rails-i18n', '~> 5.1'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.1)
       actionpack (= 5.2.1)
       activesupport (= 5.2.1)
@@ -207,6 +210,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.1)
+  rails-i18n (~> 5.1)
   rspec-rails
   rubocop (= 0.55.0)
   shoulda-matchers

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -13,13 +13,15 @@ class TodosController < ApplicationController
 
   rescue_from ActiveRecord::RecordInvalid do |e|
     errors =
-      e.record.errors.keys.map.with_index do |attribute, i|
-        {
-          title: e.record.errors.full_messages[i],
-          status: 422,
-          source: { pointer: "/#{attribute}" },
-        }
-      end
+      e.record.errors.keys.map do |attribute|
+        e.record.errors.full_messages_for(attribute).map do |msg|
+          {
+            title: msg,
+            status: 422,
+            source: { pointer: "/#{attribute}" },
+          }
+        end
+      end.flatten
 
     render json: { errors: errors }, status: 422
   end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -7,11 +7,11 @@ class TodosController < ApplicationController
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
-    pointers = []
+    errors = []
     e.record.errors.messages.keys.each do |attribute|
-      pointers << "/data/attributes/#{attribute}"
+      error = { title: I18n.t('errors.messages.invalid', locale: 'ja'), status: 422, source: { 'pointer' => "/#{attribute}" } }
+      errors << error
     end
-    errors = [{ title: I18n.t('errors.messages.invalid', locale: 'ja'), status: 422, source: { 'pointer' => pointers } }]
     render json: { errors: errors }, status: 422
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -7,10 +7,13 @@ class TodosController < ApplicationController
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
-    errors = []
-    e.record.errors.messages.keys.each do |attribute|
-      error = { title: I18n.t('errors.messages.invalid', locale: 'ja'), status: 422, source: { 'pointer' => "/#{attribute}" } }
-      errors << error
+    errors = e.record.errors.messages.keys
+    errors.map! do |attribute|
+      {
+        title: i18n_todo_attribute(attribute) + i18n_errors_messages('invalid'),
+        status: 422,
+        source: { pointer: "/#{attribute}" },
+      }
     end
     render json: { errors: errors }, status: 422
   end
@@ -47,5 +50,13 @@ class TodosController < ApplicationController
 
   def todo_params
     params.permit(:title, :text)
+  end
+
+  def i18n_todo_attribute(attribute_name)
+    I18n.t(attribute_name, scope: 'activerecord.attributes.todo', locale: 'ja')
+  end
+
+  def i18n_errors_messages(error_name)
+    I18n.t(error_name, scope: 'errors.messages', locale: 'ja')
   end
 end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -2,7 +2,12 @@ class TodosController < ApplicationController
   before_action :set_todo, only: [:show, :update, :destroy]
 
   rescue_from ActiveRecord::RecordNotFound do
-    errors = [{ title: I18n.t('errors.messages.not_found', locale: 'ja'), status: 404 }]
+    errors = [
+      {
+        title: i18n_errors_messages('not_found'),
+        status: 404,
+      },
+    ]
     render json: { errors: errors }, status: 404
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -6,6 +6,15 @@ class TodosController < ApplicationController
     render json: { errors: errors }, status: 404
   end
 
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    pointers = []
+    e.record.errors.messages.keys.each do |attribute|
+      pointers << "/data/attributes/#{attribute}"
+    end
+    errors = [{ title: I18n.t('errors.messages.invalid', locale: 'ja'), status: 422, source: { 'pointer' => pointers } }]
+    render json: { errors: errors }, status: 422
+  end
+
   def index
     todos = Todo.all.order(:created_at)
     render json: todos

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -4,7 +4,7 @@ class TodosController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound do
     errors = [
       {
-        title: i18n_errors_messages('not_found'),
+        title: I18n.t('not_found', scope: 'errors.messages'),
         status: 404,
       },
     ]
@@ -12,14 +12,15 @@ class TodosController < ApplicationController
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
-    errors = e.record.errors.messages.keys
-    errors.map! do |attribute|
-      {
-        title: i18n_todo_attribute(attribute) + i18n_errors_messages('invalid'),
-        status: 422,
-        source: { pointer: "/#{attribute}" },
-      }
-    end
+    errors =
+      e.record.errors.keys.map.with_index do |attribute, i|
+        {
+          title: e.record.errors.full_messages[i],
+          status: 422,
+          source: { pointer: "/#{attribute}" },
+        }
+      end
+
     render json: { errors: errors }, status: 422
   end
 
@@ -55,13 +56,5 @@ class TodosController < ApplicationController
 
   def todo_params
     params.permit(:title, :text)
-  end
-
-  def i18n_todo_attribute(attribute_name)
-    I18n.t(attribute_name, scope: 'activerecord.attributes.todo', locale: 'ja')
-  end
-
-  def i18n_errors_messages(error_name)
-    I18n.t(error_name, scope: 'errors.messages', locale: 'ja')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module SimpleTodoApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,14 @@
 ja:
+  activerecord:
+      models:
+        todo: Todo
+      attributes:
+        todo:
+          id: ID
+          title: タイトル
+          text: テキスト
+          created_at: 作成日時
   errors:
     messages:
-      invalid: バリデーションに失敗しました。
+      invalid: のバリデーションに失敗しました。
       not_found: 見つかりませんでした。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,14 +1,13 @@
 ja:
   activerecord:
-      models:
-        todo: Todo
-      attributes:
-        todo:
-          id: ID
-          title: タイトル
-          text: テキスト
-          created_at: 作成日時
+    models:
+      todo: Todo
+    attributes:
+      todo:
+        id: ID
+        title: タイトル
+        text: テキスト
+        created_at: 作成日時
   errors:
     messages:
-      invalid: のバリデーションに失敗しました。
       not_found: 見つかりませんでした。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,5 @@
 ja:
   errors:
     messages:
+      invalid: バリデーションに失敗しました。
       not_found: 見つかりませんでした。

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -82,12 +82,12 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'タイトルのバリデーションに失敗しました。',
+                'title' => 'タイトルを入力してください',
                 'status' => 422,
                 'source' => { 'pointer' => '/title' },
               },
               {
-                'title' => 'テキストのバリデーションに失敗しました。',
+                'title' => 'テキストを入力してください',
                 'status' => 422,
                 'source' => { 'pointer' => '/text' },
               },
@@ -116,7 +116,7 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'タイトルのバリデーションに失敗しました。',
+                'title' => 'タイトルを入力してください',
                 'status' => 422,
                 'source' => { 'pointer' => '/title' },
               },
@@ -145,7 +145,7 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'テキストのバリデーションに失敗しました。',
+                'title' => 'テキストを入力してください',
                 'status' => 422,
                 'source' => { 'pointer' => '/text' },
               },
@@ -258,12 +258,12 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'タイトルのバリデーションに失敗しました。',
+                  'title' => 'タイトルを入力してください',
                   'status' => 422,
                   'source' => { 'pointer' => '/title' },
                 },
                 {
-                  'title' => 'テキストのバリデーションに失敗しました。',
+                  'title' => 'テキストを入力してください',
                   'status' => 422,
                   'source' => { 'pointer' => '/text' },
                 },
@@ -296,7 +296,7 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'タイトルのバリデーションに失敗しました。',
+                  'title' => 'タイトルを入力してください',
                   'status' => 422,
                   'source' => { 'pointer' => '/title' },
                 },
@@ -329,7 +329,7 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'テキストのバリデーションに失敗しました。',
+                  'title' => 'テキストを入力してください',
                   'status' => 422,
                   'source' => { 'pointer' => '/text' },
                 },

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -43,30 +43,120 @@ RSpec.describe 'Todos', type: :request do
   describe 'POST /todos' do
     subject { post '/todos', params: params }
 
-    let(:params) { { title: 'Sample title', text: 'Sample text' } }
+    context 'Valid params' do
+      let(:params) { { title: 'Sample title', text: 'Sample text' } }
 
-    it 'returns HTTP Status 201' do
-      subject
-      aggregate_failures do
-        expect(response.status).to eq 201
-        expect(response.location).to eq "http://www.example.com/todos/#{Todo.last.id}"
+      it 'returns HTTP Status 201' do
+        subject
+        aggregate_failures do
+          expect(response.status).to eq 201
+          expect(response.location).to eq "http://www.example.com/todos/#{Todo.last.id}"
+        end
+      end
+
+      it 'returns input params' do
+        subject
+        result_todo = JSON.parse(response.body)
+        aggregate_failures do
+          expect(result_todo['id']).to_not be_empty
+          expect(result_todo['title']).to eq 'Sample title'
+          expect(result_todo['text']).to eq 'Sample text'
+          expect(result_todo['created_at']).to_not be_empty
+        end
+      end
+
+      it 'create 1 todo' do
+        expect { subject }.to change(Todo, :count).by(1)
       end
     end
 
-    it 'returns input params' do
-      subject
-      result_todo = JSON.parse(response.body)
+    context 'Invalid params' do
+      context 'Empty title & text' do
+        let(:params) { { title: '', text: '' } }
 
-      aggregate_failures do
-        expect(result_todo['id']).to_not be_empty
-        expect(result_todo['title']).to eq 'Sample title'
-        expect(result_todo['text']).to eq 'Sample text'
-        expect(result_todo['created_at']).to_not be_empty
+        it 'returns HTTP Status 422' do
+          subject
+          expect(response.status).to eq 422
+        end
+
+        it 'returns error JSON' do
+          expect_errors = {
+            'errors' => [
+              {
+                'title' => 'バリデーションに失敗しました。',
+                'status' => 422,
+                'source' => { 'pointer' => ['/data/attributes/title', '/data/attributes/text'] },
+              },
+            ],
+          }
+
+          subject
+          result_errors = JSON.parse(response.body)
+          expect(result_errors).to eq expect_errors
+        end
+
+        it 'not create todo' do
+          expect { subject }.to_not change(Todo, :count)
+        end
       end
-    end
 
-    it 'create 1 todo' do
-      expect { subject }.to change(Todo, :count).by(1)
+      context 'Empty title' do
+        let(:params) { { title: '', text: 'Sample text' } }
+
+        it 'returns HTTP Status 422' do
+          subject
+          expect(response.status).to eq 422
+        end
+
+        it 'returns error JSON' do
+          expect_errors = {
+            'errors' => [
+              {
+                'title' => 'バリデーションに失敗しました。',
+                'status' => 422,
+                'source' => { 'pointer' => ['/data/attributes/title'] },
+              },
+            ],
+          }
+
+          subject
+          result_errors = JSON.parse(response.body)
+          expect(result_errors).to eq expect_errors
+        end
+
+        it 'not create todo' do
+          expect { subject }.to_not change(Todo, :count)
+        end
+      end
+
+      context 'Empty text' do
+        let(:params) { { title: 'Sample text', text: '' } }
+
+        it 'returns HTTP Status 422' do
+          subject
+          expect(response.status).to eq 422
+        end
+
+        it 'returns error JSON' do
+          expect_errors = {
+            'errors' => [
+              {
+                'title' => 'バリデーションに失敗しました。',
+                'status' => 422,
+                'source' => { 'pointer' => ['/data/attributes/text'] },
+              },
+            ],
+          }
+
+          subject
+          result_errors = JSON.parse(response.body)
+          expect(result_errors).to eq expect_errors
+        end
+
+        it 'not create todo' do
+          expect { subject }.to_not change(Todo, :count)
+        end
+      end
     end
   end
 
@@ -105,9 +195,129 @@ RSpec.describe 'Todos', type: :request do
     let!(:todo) { create(:todo, title: 'Sample title', text: 'Sample text') }
     let(:params) { { title: 'Change title', text: 'Change text' } }
 
-    it 'returns HTTP Status 200' do
-      subject
-      expect(response.status).to eq 200
+    context 'Exist Record' do
+      let(:path) { "/todos/#{todo.id}" }
+
+      context 'Valid params' do
+        it 'returns HTTP Status 200' do
+          subject
+          expect(response.status).to eq 200
+        end
+
+        it 'returns update JSON' do
+          expect_todo = {
+            'id' => todo.id,
+            'title' => 'Change title',
+            'text' => 'Change text',
+            'created_at' => '2019-01-01T00:00:00Z',
+          }
+
+          subject
+          result_todo = JSON.parse(response.body)
+          expect(result_todo).to eq expect_todo
+        end
+      end
+
+      context 'Invalid params' do
+        context 'Empty title & text' do
+          let(:params) { { title: '', text: '' } }
+
+          it 'returns HTTP Status 422' do
+            subject
+            expect(response.status).to eq 422
+          end
+
+          it 'returns error JSON' do
+            expect_errors = {
+              'errors' => [
+                {
+                  'title' => 'バリデーションに失敗しました。',
+                  'status' => 422,
+                  'source' => { 'pointer' => ['/data/attributes/title', '/data/attributes/text'] },
+                },
+              ],
+            }
+
+            subject
+            result_errors = JSON.parse(response.body)
+            expect(result_errors).to eq expect_errors
+          end
+
+          it 'not change params' do
+            subject
+            aggregate_failures do
+              expect(todo.title).to eq 'Sample title'
+              expect(todo.text).to eq 'Sample text'
+            end
+          end
+        end
+
+        context 'Empty title' do
+          let(:params) { { title: '', text: 'Sample text' } }
+
+          it 'returns HTTP Status 422' do
+            subject
+            expect(response.status).to eq 422
+          end
+
+          it 'returns error JSON' do
+            expect_errors = {
+              'errors' => [
+                {
+                  'title' => 'バリデーションに失敗しました。',
+                  'status' => 422,
+                  'source' => { 'pointer' => ['/data/attributes/title'] },
+                },
+              ],
+            }
+
+            subject
+            result_errors = JSON.parse(response.body)
+            expect(result_errors).to eq expect_errors
+          end
+
+          it 'not change params' do
+            subject
+            aggregate_failures do
+              expect(todo.title).to eq 'Sample title'
+              expect(todo.text).to eq 'Sample text'
+            end
+          end
+        end
+
+        context 'Empty text' do
+          let(:params) { { title: 'Sample text', text: '' } }
+
+          it 'returns HTTP Status 422' do
+            subject
+            expect(response.status).to eq 422
+          end
+
+          it 'returns error JSON' do
+            expect_errors = {
+              'errors' => [
+                {
+                  'title' => 'バリデーションに失敗しました。',
+                  'status' => 422,
+                  'source' => { 'pointer' => ['/data/attributes/text'] },
+                },
+              ],
+            }
+
+            subject
+            result_errors = JSON.parse(response.body)
+            expect(result_errors).to eq expect_errors
+          end
+
+          it 'not change params' do
+            subject
+            aggregate_failures do
+              expect(todo.title).to eq 'Sample title'
+              expect(todo.text).to eq 'Sample text'
+            end
+          end
+        end
+      end
     end
 
     it 'returns update JSON' do

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -82,12 +82,12 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'バリデーションに失敗しました。',
+                'title' => 'タイトルのバリデーションに失敗しました。',
                 'status' => 422,
                 'source' => { 'pointer' => '/title' },
               },
               {
-                'title' => 'バリデーションに失敗しました。',
+                'title' => 'テキストのバリデーションに失敗しました。',
                 'status' => 422,
                 'source' => { 'pointer' => '/text' },
               },
@@ -116,7 +116,7 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'バリデーションに失敗しました。',
+                'title' => 'タイトルのバリデーションに失敗しました。',
                 'status' => 422,
                 'source' => { 'pointer' => '/title' },
               },
@@ -145,7 +145,7 @@ RSpec.describe 'Todos', type: :request do
           expect_errors = {
             'errors' => [
               {
-                'title' => 'バリデーションに失敗しました。',
+                'title' => 'テキストのバリデーションに失敗しました。',
                 'status' => 422,
                 'source' => { 'pointer' => '/text' },
               },
@@ -258,12 +258,12 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'バリデーションに失敗しました。',
+                  'title' => 'タイトルのバリデーションに失敗しました。',
                   'status' => 422,
                   'source' => { 'pointer' => '/title' },
                 },
                 {
-                  'title' => 'バリデーションに失敗しました。',
+                  'title' => 'テキストのバリデーションに失敗しました。',
                   'status' => 422,
                   'source' => { 'pointer' => '/text' },
                 },
@@ -296,7 +296,7 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'バリデーションに失敗しました。',
+                  'title' => 'タイトルのバリデーションに失敗しました。',
                   'status' => 422,
                   'source' => { 'pointer' => '/title' },
                 },
@@ -329,7 +329,7 @@ RSpec.describe 'Todos', type: :request do
             expect_errors = {
               'errors' => [
                 {
-                  'title' => 'バリデーションに失敗しました。',
+                  'title' => 'テキストのバリデーションに失敗しました。',
                   'status' => 422,
                   'source' => { 'pointer' => '/text' },
                 },

--- a/spec/requests/todos_spec.rb
+++ b/spec/requests/todos_spec.rb
@@ -84,7 +84,12 @@ RSpec.describe 'Todos', type: :request do
               {
                 'title' => 'バリデーションに失敗しました。',
                 'status' => 422,
-                'source' => { 'pointer' => ['/data/attributes/title', '/data/attributes/text'] },
+                'source' => { 'pointer' => '/title' },
+              },
+              {
+                'title' => 'バリデーションに失敗しました。',
+                'status' => 422,
+                'source' => { 'pointer' => '/text' },
               },
             ],
           }
@@ -113,7 +118,7 @@ RSpec.describe 'Todos', type: :request do
               {
                 'title' => 'バリデーションに失敗しました。',
                 'status' => 422,
-                'source' => { 'pointer' => ['/data/attributes/title'] },
+                'source' => { 'pointer' => '/title' },
               },
             ],
           }
@@ -142,7 +147,7 @@ RSpec.describe 'Todos', type: :request do
               {
                 'title' => 'バリデーションに失敗しました。',
                 'status' => 422,
-                'source' => { 'pointer' => ['/data/attributes/text'] },
+                'source' => { 'pointer' => '/text' },
               },
             ],
           }
@@ -255,7 +260,12 @@ RSpec.describe 'Todos', type: :request do
                 {
                   'title' => 'バリデーションに失敗しました。',
                   'status' => 422,
-                  'source' => { 'pointer' => ['/data/attributes/title', '/data/attributes/text'] },
+                  'source' => { 'pointer' => '/title' },
+                },
+                {
+                  'title' => 'バリデーションに失敗しました。',
+                  'status' => 422,
+                  'source' => { 'pointer' => '/text' },
                 },
               ],
             }
@@ -288,7 +298,7 @@ RSpec.describe 'Todos', type: :request do
                 {
                   'title' => 'バリデーションに失敗しました。',
                   'status' => 422,
-                  'source' => { 'pointer' => ['/data/attributes/title'] },
+                  'source' => { 'pointer' => '/title' },
                 },
               ],
             }
@@ -321,7 +331,7 @@ RSpec.describe 'Todos', type: :request do
                 {
                   'title' => 'バリデーションに失敗しました。',
                   'status' => 422,
-                  'source' => { 'pointer' => ['/data/attributes/text'] },
+                  'source' => { 'pointer' => '/text' },
                 },
               ],
             }


### PR DESCRIPTION
このPRにおける目的
----
- [RecordInvalid 例外処理の入力値に対する返却値 · Issue \#18 · chionyan/simple\-todo\-api](https://github.com/chionyan/simple-todo-api/issues/18#issuecomment-416460609)に従い`POST /todos` `PATCH /todos/:id` における Validation error 時の例外処理を実装する

やったこと
----
- `ActionController:: RecordInvalid ` の例外処理実装

特記事項
----
- リクエストボディは `{ "title": "...", "text": "..." }` の JSON 形式に限定する。